### PR TITLE
Updates urls.py as per the Django 2.0 changes

### DIFF
--- a/simpleblog/urls.py
+++ b/simpleblog/urls.py
@@ -1,17 +1,17 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import BlogDetailView, BlogListView, LatestEntriesFeed
 
 urlpatterns = [
-                url(r'^(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<slug>[-_\w]+)/$',
+                re_path(r'^(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<slug>[-_\w]+)/$',
                     BlogDetailView.as_view(),
                     name='blog_detail',
                     ),
-                url(r'^archive/$',
+                re_path(r'^archive/$',
                     BlogListView.as_view(
                         template_name="simpleblog/post_archive.html",
                         page_template="simpleblog/post_archive_page.html"),
                         name="blog_archive"),
-                url(r'^latest/feed/$', LatestEntriesFeed()),
-                url(r'^$', BlogListView.as_view(), name='blog_index'),
+                re_path(r'^latest/feed/$', LatestEntriesFeed()),
+                re_path(r'^$', BlogListView.as_view(), name='blog_index'),
             ]


### PR DESCRIPTION
New Django 2.0 has deprecated "url" method and introduced 2 new methods "path" for normal routing and "re_path" for routing using regex. They area available in django.urls module